### PR TITLE
Added missing classPath field in haxelib.json.

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -8,6 +8,7 @@
   "contributors": [ "TiVo" ],
   "releasenote" : "none",
   "binaryversion": 1,
+  "classPath": "src",
   "dependencies": {
   }
 }


### PR DESCRIPTION
As I've mentioned at https://github.com/TiVo/activity/issues/1#issuecomment-90668972, the repo is unusable without correct haxelib.json...
The haxelib package you submitted is unusable too due to the same issue.
